### PR TITLE
Create ble_midi_simple_scanner.py

### DIFF
--- a/examples/ble_midi_simple_scanner.py
+++ b/examples/ble_midi_simple_scanner.py
@@ -24,7 +24,6 @@ from adafruit_ble_midi import MIDIService
 
 # Use default HID descriptor
 midi_service = adafruit_ble_midi.MIDIService()
-advertisement = ProvideServicesAdvertisement(midi_service)
 
 ble = adafruit_ble.BLERadio()
 if ble.connected:
@@ -32,9 +31,6 @@ if ble.connected:
         c.disconnect()
 
 midi = adafruit_midi.MIDI(midi_out=midi_service, midi_in=midi_service, out_channel=0)
-
-print("advertising")
-ble.start_advertising(advertisement)
 
 while True:
     print("Waiting for connection to a MIDI device")

--- a/examples/ble_midi_simple_scanner.py
+++ b/examples/ble_midi_simple_scanner.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+# SPDX-FileCopyrightText: 2025 spridget
 # SPDX-License-Identifier: MIT
 
 """

--- a/examples/ble_midi_simple_scanner.py
+++ b/examples/ble_midi_simple_scanner.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+# SPDX-License-Identifier: MIT
+
+"""
+This example acts as a BLE scanner for MIDI devices.
+Specifically, it connects and pairs with a device running ble_midi_simple
+"""
+
+import time
+
+import adafruit_ble
+import adafruit_midi
+from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
+
+# These import auto-register the message type with the MIDI machinery.
+from adafruit_midi.control_change import ControlChange
+from adafruit_midi.midi_message import MIDIUnknownEvent
+from adafruit_midi.note_off import NoteOff
+from adafruit_midi.note_on import NoteOn
+from adafruit_midi.pitch_bend import PitchBend
+
+import adafruit_ble_midi
+from adafruit_ble_midi import MIDIService
+
+# Use default HID descriptor
+midi_service = adafruit_ble_midi.MIDIService()
+advertisement = ProvideServicesAdvertisement(midi_service)
+
+ble = adafruit_ble.BLERadio()
+if ble.connected:
+    for c in ble.connections:
+        c.disconnect()
+
+midi = adafruit_midi.MIDI(midi_out=midi_service, midi_in=midi_service, out_channel=0)
+
+print("advertising")
+ble.start_advertising(advertisement)
+
+while True:
+    print("Waiting for connection to a MIDI device")
+    for advertisement in ble.start_scan(ProvideServicesAdvertisement, timeout=60):
+        if MIDIService not in advertisement.services:
+            continue
+        ble.connect(advertisement)
+        break
+
+    if ble.connections:
+        for connection in ble.connections:
+            if connection.connected and not connection.paired:
+                print("Connected; Pairing with the MIDI device")
+                connection.pair()
+
+        if connection.connected and connection.paired:
+            print("Paired")
+            midi_service = connection[MIDIService]
+            midi = adafruit_midi.MIDI(midi_out=midi_service, midi_in=midi_service)
+
+            while ble.connected:
+                midi_in = midi.receive()
+                while midi_in:
+                    if not isinstance(midi_in, MIDIUnknownEvent):
+                        print(time.monotonic(), midi_in)
+                    midi_in = midi.receive()
+            print("Disconnected")
+            print()


### PR DESCRIPTION
This program is a BLE scanner to connect and pair with the BLE advertiser in ble_midi_simple.py. It receives and prints timestamps for all MIDI packets received once it has connected and paired with another device.